### PR TITLE
Fix duplicate track selection and region management

### DIFF
--- a/src/AudioRecorder.jsx
+++ b/src/AudioRecorder.jsx
@@ -592,13 +592,14 @@ const AudioRecorder = ({ audioUrl, setAudioUrl, obs, metadata }) => {
 
     useEffect(() => {
         if (!regionsPlugin || !wavesurfer) return;
-        if (!regionsPlugin.__dragSelectionEnabled) {
+        const ws = wavesurfer;
+        if (regionsPlugin.__dragSelectionWs !== ws) {
             try {
                 regionsPlugin.enableDragSelection({
                     drag: true,
                     color: 'rgba(0, 0, 0, 0.2)',
                 }, 1);
-                regionsPlugin.__dragSelectionEnabled = true;
+                regionsPlugin.__dragSelectionWs = ws;
             } catch (_) {}
         }
         regionsPlugin.on('region-created', handleRegionCreate);

--- a/src/AudioRecorder.jsx
+++ b/src/AudioRecorder.jsx
@@ -571,6 +571,25 @@ const AudioRecorder = ({ audioUrl, setAudioUrl, obs, metadata }) => {
 
     }, [wavesurfer, handleReady, handleLoading, handleTimeUpdate]);
 
+    const handleRegionCreate = (region) => {
+        if (handleRegionSelect) {
+            // Identifie explicitement la piste principale comme "0"
+            handleRegionSelect([region, "0", regionsPlugin]);
+        }
+    };
+
+    const handleRegionUpdate = (region) => {
+        if (handleRegionSelect) {
+            // Identifie explicitement la piste principale comme "0"
+            handleRegionSelect([region, "0", regionsPlugin]);
+        }
+    };
+
+    const handleRegionClick = (region) => {
+        // Identifie explicitement la piste principale comme "0"
+        handleRegionSelect([region, "0", regionsPlugin]);
+    };
+
     useEffect(() => {
         if (!regionsPlugin || !wavesurfer) return;
         if (!regionsPlugin.__dragSelectionEnabled) {
@@ -593,26 +612,6 @@ const AudioRecorder = ({ audioUrl, setAudioUrl, obs, metadata }) => {
         };
 
     }, [wavesurfer, regionsPlugin, handleRegionCreate, handleRegionUpdate, handleRegionClick]);
-
-    const handleRegionCreate = (region) => {
-        if (handleRegionSelect) {
-            // Identifie explicitement la piste principale comme "0"
-            handleRegionSelect([region, "0", regionsPlugin]);
-        }
-    };
-
-    const handleRegionUpdate = (region) => {
-        if (handleRegionSelect) {
-            // Identifie explicitement la piste principale comme "0"
-            handleRegionSelect([region, "0", regionsPlugin]);
-        }
-    };
-
-    const handleRegionClick = (region) => {
-        // Identifie explicitement la piste principale comme "0"
-        handleRegionSelect([region, "0", regionsPlugin]);
-    };
-
 
     useEffect(() => {
         const updateAudioUrl = async () => {

--- a/src/AudioRecorder.jsx
+++ b/src/AudioRecorder.jsx
@@ -572,15 +572,27 @@ const AudioRecorder = ({ audioUrl, setAudioUrl, obs, metadata }) => {
     }, [wavesurfer, handleReady, handleLoading, handleTimeUpdate]);
 
     useEffect(() => {
-        regionsPlugin?.enableDragSelection({
-            drag: true,
-            color: 'rgba(0, 0, 0, 0.2)',
-        }, 1);
-        regionsPlugin?.on('region-created', handleRegionCreate);
-        regionsPlugin?.on('region-updated', handleRegionUpdate);
-        regionsPlugin?.on('region-clicked', handleRegionClick);
+        if (!regionsPlugin || !wavesurfer) return;
+        if (!regionsPlugin.__dragSelectionEnabled) {
+            try {
+                regionsPlugin.enableDragSelection({
+                    drag: true,
+                    color: 'rgba(0, 0, 0, 0.2)',
+                }, 1);
+                regionsPlugin.__dragSelectionEnabled = true;
+            } catch (_) {}
+        }
+        regionsPlugin.on('region-created', handleRegionCreate);
+        regionsPlugin.on('region-updated', handleRegionUpdate);
+        regionsPlugin.on('region-clicked', handleRegionClick);
 
-    }, [wavesurfer]);
+        return () => {
+            regionsPlugin.un('region-created', handleRegionCreate);
+            regionsPlugin.un('region-updated', handleRegionUpdate);
+            regionsPlugin.un('region-clicked', handleRegionClick);
+        };
+
+    }, [wavesurfer, regionsPlugin, handleRegionCreate, handleRegionUpdate, handleRegionClick]);
 
     const handleRegionCreate = (region) => {
         if (handleRegionSelect) {

--- a/src/AudioRecorder.jsx
+++ b/src/AudioRecorder.jsx
@@ -602,14 +602,24 @@ const AudioRecorder = ({ audioUrl, setAudioUrl, obs, metadata }) => {
                 regionsPlugin.__dragSelectionWs = ws;
             } catch (_) {}
         }
-        regionsPlugin.on('region-created', handleRegionCreate);
+        // Ensure only one region on main track at a time
+        const wrappedCreate = (region) => {
+            try { regionsPlugin.getRegions().forEach(r => { if (r !== region) r.remove(); }); } catch (_) {}
+            handleRegionCreate(region);
+        };
+        const wrappedClick = (region) => {
+            try { regionsPlugin.getRegions().forEach(r => { if (r !== region) r.remove(); }); } catch (_) {}
+            handleRegionClick(region);
+        };
+
+        regionsPlugin.on('region-created', wrappedCreate);
         regionsPlugin.on('region-updated', handleRegionUpdate);
-        regionsPlugin.on('region-clicked', handleRegionClick);
+        regionsPlugin.on('region-clicked', wrappedClick);
 
         return () => {
-            regionsPlugin.un('region-created', handleRegionCreate);
+            regionsPlugin.un('region-created', wrappedCreate);
             regionsPlugin.un('region-updated', handleRegionUpdate);
-            regionsPlugin.un('region-clicked', handleRegionClick);
+            regionsPlugin.un('region-clicked', wrappedClick);
         };
 
     }, [wavesurfer, regionsPlugin, handleRegionCreate, handleRegionUpdate, handleRegionClick]);

--- a/src/Waveform.jsx
+++ b/src/Waveform.jsx
@@ -200,21 +200,16 @@ const Waveform = ({
 
     useEffect(() => {
         if (!enableRegions || !regionsPlugin || !wavesurfer) return;
-        // Prevent double init on re-renders
-        if (regionsPlugin.__dragSelectionEnabled) return;
-        try {
-            regionsPlugin.enableDragSelection({
-                drag: true,
-                color: 'rgba(0, 0, 0, 0.2)'
-            });
-            regionsPlugin.__dragSelectionEnabled = true;
-        } catch (e) {
-            // noop
+        const ws = wavesurfer;
+        if (regionsPlugin.__dragSelectionWs !== ws) {
+            try {
+                regionsPlugin.enableDragSelection({
+                    drag: true,
+                    color: 'rgba(0, 0, 0, 0.2)'
+                });
+                regionsPlugin.__dragSelectionWs = ws;
+            } catch (e) {}
         }
-        return () => {
-            // no API to disable dragSelection directly, but we can clear the flag on unmount
-            regionsPlugin.__dragSelectionEnabled = false;
-        };
     }, [enableRegions, regionsPlugin, wavesurfer]);
 
     const updateActualDuration = () => {

--- a/src/Waveform.jsx
+++ b/src/Waveform.jsx
@@ -142,12 +142,19 @@ const Waveform = ({
 
         if (enableRegions) {
             handleRegionCreate = (region) => {
+                // Always keep only one region on this track
+                try {
+                    regionsPlugin.getRegions().forEach(r => { if (r !== region) r.remove(); });
+                } catch (_) {}
                 if (onRegionSelect) {
                     onRegionSelect([region, priseNumber, regionsPlugin]);
                 }
             };
 
             handleRegionClick = (region) => {
+                try {
+                    regionsPlugin.getRegions().forEach(r => { if (r !== region) r.remove(); });
+                } catch (_) {}
                 if (onRegionSelect) {
                     onRegionSelect([region, priseNumber, regionsPlugin]);
                 }


### PR DESCRIPTION
Make region drag selection idempotent and add event listener cleanup to fix double region creation and ensure previous regions are cleared.

---
<a href="https://cursor.com/background-agent?bcId=bc-20993492-69c3-4a55-b61d-60397edc2f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20993492-69c3-4a55-b61d-60397edc2f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

